### PR TITLE
Add DestroyVoxels tag

### DIFF
--- a/Data/Scripts/ToolCore/Definitions/SerializedDefinitions/Definitions.cs
+++ b/Data/Scripts/ToolCore/Definitions/SerializedDefinitions/Definitions.cs
@@ -32,6 +32,7 @@ namespace ToolCore.Definitions.Serialised
         public float Length = 1f; //Cylinder, Line
         public float Speed = 1f;
         public float HarvestRatio = 1f;
+        public bool DestroyVoxels = true;
         public int WorkRate = int.MaxValue;
         public int UpdateInterval = 20;
 
@@ -69,6 +70,8 @@ namespace ToolCore.Definitions.Serialised
         public float SpeedRatio = 1f;
         [XmlAttribute]
         public float HarvestRatio = 1f;
+        [XmlAttribute]
+        public bool DestroyVoxels = true;
     }
 
     public class Event

--- a/Data/Scripts/ToolCore/Definitions/ToolDefinition.cs
+++ b/Data/Scripts/ToolCore/Definitions/ToolDefinition.cs
@@ -117,16 +117,18 @@ namespace ToolCore.Definitions
         {
             internal float Speed;
             internal float HarvestRatio;
+            internal bool DestroyVoxels;
 
             internal Vector3 HalfExtent;
             internal float Radius;
             internal float Length;
             internal float BoundingRadius;
 
-            public ActionDefinition(ActionValues values, float speed, float harvestRatio, Vector3 half, float radius, float length, float bRadius, EffectShape shape)
+            public ActionDefinition(ActionValues values, float speed, float harvestRatio, bool destroyVoxels, Vector3 half, float radius, float length, float bRadius, EffectShape shape)
             {
                 Speed = speed * values.SpeedRatio;
                 HarvestRatio = harvestRatio * values.HarvestRatio;
+                DestroyVoxels = destroyVoxels;
                 HalfExtent = half * values.SizeRatio;
                 Radius = radius * values.SizeRatio;
                 Length = length;
@@ -139,10 +141,11 @@ namespace ToolCore.Definitions
                 }
             }
 
-            public ActionDefinition(float speed, float harvestRatio, Vector3 half, float radius, float length, float bRadius)
+            public ActionDefinition(float speed, float harvestRatio, bool destroyVoxels, Vector3 half, float radius, float length, float bRadius)
             {
                 Speed = speed;
                 HarvestRatio = harvestRatio;
+                DestroyVoxels = destroyVoxels;
                 HalfExtent = half;
                 Radius = radius;
                 Length = length;
@@ -319,6 +322,7 @@ namespace ToolCore.Definitions
         {
             var speed = values.Speed;
             var hRatio = values.HarvestRatio;
+            var destroyVoxels = values.DestroyVoxels;
 
             var halfExtent = (Vector3)values.HalfExtent;
             var radius = values.Radius;
@@ -384,14 +388,14 @@ namespace ToolCore.Definitions
 
             if (values.Actions == null || values.Actions.Length == 0)
             {
-                ActionMap.Add(ToolAction.Primary, new ActionDefinition(speed, hRatio, halfExtent, radius, length, boundingRadius));
+                ActionMap.Add(ToolAction.Primary, new ActionDefinition(speed, hRatio, destroyVoxels, halfExtent, radius, length, boundingRadius));
                 ToolActions.Add(ToolAction.Primary);
                 return;
             }
 
             foreach (var action in values.Actions)
             {
-                var actionValues = new ActionDefinition(action, speed, hRatio, halfExtent, radius, length, boundingRadius, EffectShape);
+                var actionValues = new ActionDefinition(action, speed, hRatio, destroyVoxels, halfExtent, radius, length, boundingRadius, EffectShape);
                 ActionMap.Add((ToolAction)action.Type, actionValues);
                 ToolActions.Add((ToolAction)action.Type);
             }

--- a/Data/Scripts/ToolCore/Utils/VoxelUtils.cs
+++ b/Data/Scripts/ToolCore/Utils/VoxelUtils.cs
@@ -448,14 +448,11 @@ namespace ToolCore
                             break;
                     }
 
-                    if (removedContent)
+                    if (removedContent && toolValues.DestroyVoxels)
                     {
                         comp.Working = true;
                         drillData.StorageDatas.Add(new StorageInfo(min, max, true));
-						if (toolValues.DestroyVoxels)
-						{
-							voxel.Storage.WriteRange(data, MyStorageDataTypeFlags.Content, min, max, false);
-						}
+						voxel.Storage.WriteRange(data, MyStorageDataTypeFlags.Content, min, max, false);
                     }
 
                 }
@@ -907,14 +904,10 @@ namespace ToolCore
                             break;
                     }
 
-                    if (removedContent)
+                    if (removedContent && toolValues.DestroyVoxels)
                     {
                         drillData.StorageDatas.Add(new StorageInfo(min, max, true));
-
-						if (toolValues.DestroyVoxels)
-						{
-							voxel.Storage.WriteRange(data, MyStorageDataTypeFlags.Content, min, max, false);
-						}
+						voxel.Storage.WriteRange(data, MyStorageDataTypeFlags.Content, min, max, false);
                     }
 
                 }

--- a/Data/Scripts/ToolCore/Utils/VoxelUtils.cs
+++ b/Data/Scripts/ToolCore/Utils/VoxelUtils.cs
@@ -229,10 +229,13 @@ namespace ToolCore
                                     comp.Yields[voxelDef.MinedOre] += yield;
                             }
 
-                            var newContent = content - removal;
-                            data.Content(index, (byte)newContent);
-                            if (newContent == 0)
-                                data.Material(index, byte.MaxValue);
+							if (toolValues.DestroyVoxels)
+							{
+								var newContent = content - removal;
+								data.Content(index, (byte)newContent);
+								if (newContent == 0)
+									data.Material(index, byte.MaxValue);
+							}
                         }
 
                         reduction -= maxContent;
@@ -240,8 +243,10 @@ namespace ToolCore
                             break;
                     }
 
-                    voxel.Storage.WriteRange(data, MyStorageDataTypeFlags.Content, min, max, false);
-
+					if (toolValues.DestroyVoxels)
+					{
+						voxel.Storage.WriteRange(data, MyStorageDataTypeFlags.Content, min, max, false);
+					}
                 }
                 drillData.WorkLayers.Clear();
 
@@ -429,10 +434,13 @@ namespace ToolCore
                                     comp.Yields[voxelDef.MinedOre] += yield;
                             }
 
-                            var newContent = content - removal;
-                            data.Content(index, (byte)newContent);
-                            if (newContent == 0)
-                                data.Material(index, byte.MaxValue);
+							if (toolValues.DestroyVoxels)
+							{
+								var newContent = content - removal;
+								data.Content(index, (byte)newContent);
+								if (newContent == 0)
+									data.Material(index, byte.MaxValue);
+							}
                         }
 
                         reduction -= maxContent;
@@ -444,7 +452,10 @@ namespace ToolCore
                     {
                         comp.Working = true;
                         drillData.StorageDatas.Add(new StorageInfo(min, max, true));
-                        voxel.Storage.WriteRange(data, MyStorageDataTypeFlags.Content, min, max, false);
+						if (toolValues.DestroyVoxels)
+						{
+							voxel.Storage.WriteRange(data, MyStorageDataTypeFlags.Content, min, max, false);
+						}
                     }
 
                 }
@@ -675,10 +686,13 @@ namespace ToolCore
                                     comp.Yields[voxelDef.MinedOre] += yield;
                             }
 
-                            var newContent = content - removal;
-                            data.Content(index, (byte)newContent);
-                            if (newContent == 0)
-                                data.Material(index, byte.MaxValue);
+							if (toolValues.DestroyVoxels)
+							{
+								var newContent = content - removal;
+								data.Content(index, (byte)newContent);
+								if (newContent == 0)
+									data.Material(index, byte.MaxValue);
+							}
                         }
 
                         reduction -= maxContent;
@@ -687,7 +701,10 @@ namespace ToolCore
                     }
                     drillData.WorkLayers.Clear();
 
-                    voxel.Storage.WriteRange(data, MyStorageDataTypeFlags.Content, min, max, false);
+					if (toolValues.DestroyVoxels)
+					{
+						voxel.Storage.WriteRange(data, MyStorageDataTypeFlags.Content, min, max, false);
+					}
 
                     if (reduction <= 0 && (int)def.Pattern > 2)
                         break;
@@ -876,10 +893,13 @@ namespace ToolCore
                                     comp.Yields[voxelDef.MinedOre] += yield;
                             }
 
-                            var newContent = content - removal;
-                            data.Content(index, (byte)newContent);
-                            if (newContent == 0)
-                                data.Material(index, byte.MaxValue);
+							if (toolValues.DestroyVoxels)
+							{
+								var newContent = content - removal;
+								data.Content(index, (byte)newContent);
+								if (newContent == 0)
+									data.Material(index, byte.MaxValue);
+							}
                         }
 
                         reduction -= maxContent;
@@ -890,7 +910,11 @@ namespace ToolCore
                     if (removedContent)
                     {
                         drillData.StorageDatas.Add(new StorageInfo(min, max, true));
-                        voxel.Storage.WriteRange(data, MyStorageDataTypeFlags.Content, min, max, false);
+
+						if (toolValues.DestroyVoxels)
+						{
+							voxel.Storage.WriteRange(data, MyStorageDataTypeFlags.Content, min, max, false);
+						}
                     }
 
                 }


### PR DESCRIPTION
Added DestroyVoxels tag. 
False = Do not destroy mined voxels
True = Do destroy mined voxels.

Meant to mimic behavior of mods like ResourceNodes. Mining without voxel editing is desirable in many server environments.
