### PR TITLE
Initial Commit for TrackTarget merge into Activate,Added ShowInToolbarConfig Toggle to refresh control panel UI for UseWorkColor toggled, Added force3D for spatial sound in 3DWorldPosition, Added sound update to restore sound when player leaves and returns to tools max sound distance.

### DIFF
--- a/Data/Scripts/ToolCore/Comp/ToolComp.cs
+++ b/Data/Scripts/ToolCore/Comp/ToolComp.cs
@@ -982,6 +982,8 @@ namespace ToolCore.Comp
                 ShowInToolbarSwitch.Setter(BlockTool, !originalSetting);
                 ShowInToolbarSwitch.Setter(BlockTool, originalSetting);
             }
+            // A toggle to refresh the block controls so UseWorkColor is refreshed automaticly. 
+            BlockTool.ShowInToolbarConfig = !BlockTool.ShowInToolbarConfig;
         }
 
         private void StorageInit()

--- a/Data/Scripts/ToolCore/Comp/ToolComp.cs
+++ b/Data/Scripts/ToolCore/Comp/ToolComp.cs
@@ -983,7 +983,10 @@ namespace ToolCore.Comp
                 ShowInToolbarSwitch.Setter(BlockTool, originalSetting);
             }
             // A toggle to refresh the block controls so UseWorkColor is refreshed automaticly. 
-            BlockTool.ShowInToolbarConfig = !BlockTool.ShowInToolbarConfig;
+            // Save the initial state of ShowInToolbarConfig
+            bool originalState = BlockTool.ShowInToolbarConfig;
+            BlockTool.ShowInToolbarConfig = !originalState;
+            BlockTool.ShowInToolbarConfig = originalState;
         }
 
         private void StorageInit()

--- a/Data/Scripts/ToolCore/Comp/ToolComp.cs
+++ b/Data/Scripts/ToolCore/Comp/ToolComp.cs
@@ -50,7 +50,6 @@ namespace ToolCore.Comp
         internal ToolRepo Repo;
 
         internal Task GridsTask = new Task();
-        internal IMyTerminalControlOnOffSwitch ShowInToolbarSwitch;
 
         internal ToolMode Mode;
         internal ToolAction Action;
@@ -258,7 +257,7 @@ namespace ToolCore.Comp
 
             if (!ToolSession.Instance.IsDedicated)
             {
-                GetShowInToolbarSwitch();
+
                 BlockTool.AppendingCustomInfo += AppendingCustomData;
                 RefreshTerminal();
             }
@@ -955,38 +954,22 @@ namespace ToolCore.Comp
             }
 
         }
-
-        private void GetShowInToolbarSwitch()
-        {
-            List<IMyTerminalControl> items;
-            MyAPIGateway.TerminalControls.GetControls<IMyUpgradeModule>(out items);
-
-            foreach (var item in items)
-            {
-
-                if (item.Id == "ShowInToolbarConfig")
-                {
-                    ShowInToolbarSwitch = (IMyTerminalControlOnOffSwitch)item;
-                    break;
-                }
-            }
-        }
-
+        // Simplified the toggle of ShowInToolbarConfig without querying
         internal void RefreshTerminal()
         {
             BlockTool.RefreshCustomInfo();
 
-            if (ShowInToolbarSwitch != null)
+            if (BlockTool != null)
             {
-                var originalSetting = ShowInToolbarSwitch.Getter(BlockTool);
-                ShowInToolbarSwitch.Setter(BlockTool, !originalSetting);
-                ShowInToolbarSwitch.Setter(BlockTool, originalSetting);
+                // Get the current setting of ShowInToolbarConfig
+                bool originalSetting = BlockTool.ShowInToolbarConfig;
+
+                // Temporarily toggle it
+                BlockTool.ShowInToolbarConfig = !originalSetting;
+
+                // Immediately reset it back to the original state
+                BlockTool.ShowInToolbarConfig = originalSetting;
             }
-            // A toggle to refresh the block controls so UseWorkColor is refreshed automaticly. 
-            // Save the initial state of ShowInToolbarConfig
-            bool originalState = BlockTool.ShowInToolbarConfig;
-            BlockTool.ShowInToolbarConfig = !originalState;
-            BlockTool.ShowInToolbarConfig = originalState;
         }
 
         private void StorageInit()
@@ -1060,7 +1043,6 @@ namespace ToolCore.Comp
             Grid = null;
             GridComp = null;
 
-            ShowInToolbarSwitch = null;
         }
 
         public override string ComponentTypeDebugString => "ToolCore";

--- a/Data/Scripts/ToolCore/Session/SessionAv.cs
+++ b/Data/Scripts/ToolCore/Session/SessionAv.cs
@@ -322,6 +322,10 @@ namespace ToolCore.Session
                 //Logs.WriteLine($"Playing sound {sound.Name}");
             }
 
+            // ✅ Ensure the emitter updates to check distance and restart if needed
+            // This is if a tool block was activate far away from a player it will restart
+            // the sound when the player comes within range again.
+            emitter.Update();
         }
 
     }

--- a/Data/Scripts/ToolCore/Session/SessionAv.cs
+++ b/Data/Scripts/ToolCore/Session/SessionAv.cs
@@ -318,7 +318,7 @@ namespace ToolCore.Session
                 if (soundPair == null)
                     return;
 
-                emitter.PlaySound(soundPair);
+                emitter.PlaySound(soundPair, force3D: true);
                 //Logs.WriteLine($"Playing sound {sound.Name}");
             }
 

--- a/Data/Scripts/ToolCore/Session/SessionAv.cs
+++ b/Data/Scripts/ToolCore/Session/SessionAv.cs
@@ -318,9 +318,8 @@ namespace ToolCore.Session
                 if (soundPair == null)
                     return;
 
-                // ✅ Attach sound to the entity so ALL clients hear it
-                emitter.Entity = comp.ToolEntity;  // 👈 Attach sound to the block entity
-                emitter.PlaySound(soundPair, force3D: true);
+                emitter.PlaySound(soundPair);
+                //Logs.WriteLine($"Playing sound {sound.Name}");
             }
 
         }

--- a/Data/Scripts/ToolCore/Session/SessionAv.cs
+++ b/Data/Scripts/ToolCore/Session/SessionAv.cs
@@ -318,8 +318,9 @@ namespace ToolCore.Session
                 if (soundPair == null)
                     return;
 
-                emitter.PlaySound(soundPair);
-                //Logs.WriteLine($"Playing sound {sound.Name}");
+                // ✅ Attach sound to the entity so ALL clients hear it
+                emitter.Entity = comp.ToolEntity;  // 👈 Attach sound to the block entity
+                emitter.PlaySound(soundPair, force3D: true);
             }
 
         }

--- a/ToolCore.csproj
+++ b/ToolCore.csproj
@@ -76,28 +76,25 @@
       <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\netstandard.dll</HintPath>
     </Reference>
     <Reference Include="ProtoBuf.Net">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\ProtoBuf.Net.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\ProtoBuf.Net.dll</HintPath>
     </Reference>
     <Reference Include="ProtoBuf.Net.Core">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\ProtoBuf.Net.Core.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\ProtoBuf.Net.Core.dll</HintPath>
     </Reference>
     <Reference Include="Sandbox.Common">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\Sandbox.Common.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\Sandbox.Common.dll</HintPath>
     </Reference>
     <Reference Include="Sandbox.Game">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\Sandbox.Game.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\Sandbox.Game.dll</HintPath>
+    </Reference>
+    <Reference Include="Sandbox.Game.XmlSerializers">
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\Sandbox.Game.XmlSerializers.dll</HintPath>
     </Reference>
     <Reference Include="SpaceEngineers.Game">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\SpaceEngineers.Game.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\SpaceEngineers.Game.dll</HintPath>
     </Reference>
     <Reference Include="SpaceEngineers.ObjectBuilders">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\SpaceEngineers.ObjectBuilders.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\SpaceEngineers.ObjectBuilders.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -121,40 +118,40 @@
       <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\System.Xml.XPath.dll</HintPath>
     </Reference>
     <Reference Include="VRage">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\VRage.dll</HintPath>
+    </Reference>
+    <Reference Include="VRage.Audio">
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\VRage.Audio.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Game">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Game.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\VRage.Game.dll</HintPath>
+    </Reference>
+    <Reference Include="VRage.Game.XmlSerializers">
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\VRage.Game.XmlSerializers.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Input">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Input.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\VRage.Input.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Library">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Library.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\VRage.Library.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Math">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Math.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\VRage.Math.dll</HintPath>
     </Reference>
-    <Reference Include="VRage.Mod.Io">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Mod.Io.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="VRage.NativeWrapper">
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\VRage.NativeWrapper.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Platform.Windows">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Platform.Windows.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\VRage.Platform.Windows.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Render">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Render.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\VRage.Render.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Render11">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\VRage.Render11.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\VRage.Render11.dll</HintPath>
+    </Reference>
+    <Reference Include="VRage.XmlSerializers">
+      <HintPath>F:\SteamLibrary\steamapps\common\SpaceEngineers\Bin64\VRage.XmlSerializers.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
For more simpler and user friendly On/Off toggle Activate. It makes it easier from a players perspective. But its up to you Ash if you ever want to use it. TrackTargets is still there just // out the control methods and implemented if (IsTurret) calls in the various Activate methods. So it can be used for something else perhaps. Disregard the project file ofc. The merge for controls TrackTargets into Activate is simple. It cant be compared to a weaponcore turret. It is a tool. It should not weld or grind when only TrackTargets its On. Wich is what its currently doing without a visible beam. And also at the same time it makes it easier for players that are used to a On/Off for most blocks. 